### PR TITLE
SAUCE_URL should be app.saucelabs.com

### DIFF
--- a/sauce.py
+++ b/sauce.py
@@ -25,7 +25,7 @@ STARS = "**********************************************************************"
 TEST_URL = "https://saucelabs.com/jobs/%s?auth=%s"
 
 #environment saucelabs variables
-SAUCE_URL = "https://saucelabs.com/rest/v1/"
+SAUCE_URL = "https://app.saucelabs.com/rest/v1/"
 SAUCE_USER = os.environ.get('SAUCE_USERNAME')
 SAUCE_ACCESS_KEY = os.environ.get('SAUCE_ACCESS_KEY')
 START_TIME = str(int(os.environ.get('INIT_START_TIME')) - 100)


### PR DESCRIPTION
Use app.saucelabs.com as the SAUCE_URL because of an SSL issue with Python's request package that was blocking requests to saucelabs.com because the hostname didn't match app.saucelabs.com